### PR TITLE
fix chmod error on compose when no file exists

### DIFF
--- a/plugins/compose.sh
+++ b/plugins/compose.sh
@@ -252,7 +252,7 @@ init-data-containers()
         DatabaseBackup::ReplaceInDumpFile
 
         # fix errors because init-db.sh is not executable :
-        chmod ugo+x db/*.sh
+        [ -f db/*.sh ] && chmod ugo+x db/*.sh
 
         # If no healthcheck is configured in compose.yaml
         # Start Database and wait for connexion is ready


### PR DESCRIPTION
quand on fait un jetdocker compose run --rm setup sur le projet jm_joomla, ça pète une erreur car ça trouve pas de fichier à modifier