### PR TITLE
Pin jwilder/docker-gen to a known-working digest

### DIFF
--- a/jetdocker.sh
+++ b/jetdocker.sh
@@ -141,8 +141,8 @@ Jetdocker::Update()
     previousPath=$(pwd)
     cd "$JETDOCKER" || exit
     echo "$(UI.Color.Green)"
-    echo "Pulling latest version of jwilder/docker-gen"
-    docker pull jwilder/docker-gen
+    echo "Pulling pinned version of jwilder/docker-gen (0.17.2, verified working on arm64 - 2026-07-13)"
+    docker pull jwilder/docker-gen@sha256:722ed281bf25e53897cfc01653f24d023d129dddee58b60be8a007c9caa21a95
     echo "Upgrading jetdocker"
     echo ""
     if git pull --rebase --stat origin master

--- a/plugins/phpmyadmin.sh
+++ b/plugins/phpmyadmin.sh
@@ -81,7 +81,7 @@ EOM
         -v /tmp/phpmyadmin:/etc/phpmyadmin/ \
         -v /var/run/docker.sock:/tmp/docker.sock:ro \
         -v $templateDir:/etc/docker-gen/templates \
-        -t jwilder/docker-gen docker-gen \
+        -t jwilder/docker-gen@sha256:722ed281bf25e53897cfc01653f24d023d129dddee58b60be8a007c9caa21a95 docker-gen \
         /etc/docker-gen/templates/pma.config.tmpl /etc/phpmyadmin/config.user.inc.php
 
     echo "Start PhpMyAdmin"

--- a/plugins/up.sh
+++ b/plugins/up.sh
@@ -315,7 +315,7 @@ EOM
         --volumes-from nginx-reverse-proxy \
         -v /var/run/docker.sock:/tmp/docker.sock:ro \
         -v $templateDir:/etc/docker-gen/templates \
-        -t jwilder/docker-gen \
+        -t jwilder/docker-gen@sha256:722ed281bf25e53897cfc01653f24d023d129dddee58b60be8a007c9caa21a95 \
         -notify-sighup nginx-reverse-proxy -watch -only-exposed \
         /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
 


### PR DESCRIPTION
## Problème

`jwilder/docker-gen` est référencé sans version (implicitement `:latest`)
à 3 endroits : `jetdocker.sh` (commande `update`), `plugins/up.sh`
(générateur de conf du reverse-proxy) et `plugins/phpmyadmin.sh`.

Le 2026-07-13, le build `latest` en amont a été republié et plante
systématiquement au démarrage (exit 127, aucun log). Sur toute machine
où le cache d'image local a été vidé (mise à jour Docker Desktop,
`docker system prune`...), le prochain `jetdocker up` retélécharge ce
build cassé : `nginx-reverse-proxy-gen` ne démarre plus, la conf du
reverse-proxy n'est plus régénérée, et tous les projets passent en 502
dès qu'un conteneur change d'IP.

## Fix

Pin sur le digest du tag `0.17.2` (2026-07-11), dernier build connu
fonctionnel avant la régression — testé en isolation (conteneur
temporaire, fichier de sortie séparé) : démarre correctement, génère
la conf à partir des conteneurs actifs, watch les events Docker.

## Test

- Pull de l'image par digest : OK
- Run isolé avec les mêmes volumes/commande que `up.sh` : conteneur
  `Up`, logs montrant une génération de conf réussie
- Bascule en prod sur `nginx-reverse-proxy-gen` réel : conteneur stable,
  conf régénérée, reverse-proxy rechargé sans erreur, site de nouveau
  accessible