### PR TITLE
Skip /etc/hosts prompt when the host already resolves

### DIFF
--- a/plugins/compose.sh
+++ b/plugins/compose.sh
@@ -149,6 +149,19 @@ Compose::CheckLocalHostName()
 
     for VHOST in $(echo $VIRTUAL_HOST | tr "," " ")
     do
+        # Skip the /etc/hosts prompt when the host already resolves
+        # (wildcard DNS via dnsmasq, /etc/resolver, company DNS, ...)
+        if [ "$OSTYPE" != 'linux-gnu' ]; then
+            if dscacheutil -q host -a name "$VHOST" 2>/dev/null | grep -q ip_address; then
+                Log "$VHOST already resolves, skip /etc/hosts check"
+                continue
+            fi
+        else
+            if getent hosts "$VHOST" > /dev/null 2>&1; then
+                Log "$VHOST already resolves, skip /etc/hosts check"
+                continue
+            fi
+        fi
         Log "Check if $VHOST is in /etc/hosts"
         try {
           grep "127.0.0.1[[:blank:]]*$VHOST" /etc/hosts > /dev/null 2>&1


### PR DESCRIPTION
Compose::CheckLocalHostName prompted to add each VIRTUAL_HOST to /etc/hosts even when the host already resolves through wildcard DNS (dnsmasq, /etc/resolver, company DNS). Test resolution first (dscacheutil on macOS, getent on Linux) and skip silently when it succeeds. The prompt still shows for setups without a local resolver.

Supersedes the unmerged fix/etc_hosts branch which disabled the check entirely.